### PR TITLE
removed tatch capital

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ do your own research!
 * [Lykke](https://www.lykke.com/)
 * [PalmPay](https://PalmPay.io) - A chain-agnostic Point Of Sale system, using Bitshares DEx, in 104 languages.
 * [Quintric](https://quintric.com/)
-* [Tatch Capital](https://tatchcapital.com/)
 
 ### Legal
 


### PR DESCRIPTION
removed tatch capital. 
reason: https://medium.com/@tatchcapital/tatch-move-to-eos-bitshares-is-decommissioned-f2cdf5956744