### PR TITLE
removed nowcoin and everprove. renamed dexgames to SmartHoldem for cl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,12 +208,11 @@ do your own research!
 
 ### Legal
 
-* [Everprove](https://www.everprove.com/)
+* Everprove; Needs BTS upgrade. Will be removed from here on Aug 1st, 2020 if upgrade not completed by then.
 
 ### Games
 
-* [DexGames](https://dexgames.net/)
-* [Nowcoin](https://nowcoingame.com/)
+* [SmartHoldem](https://dexgames.net/) 
 
 ## Other Blockchains in the BitShares Family
 


### PR DESCRIPTION
…arity.

no reply from Zoltan Toth (regarding nowcoin and everprove), and community has stated "Nowcoin is dead (finished its last round and merchant integration never came) . Everprove moved to a bitcoin fork." 
 
their telegram channel has not had any announcements since july of last year: 
https://www.t.me/nowcoingame 
https://bts.ai/asset/NOWCOIN 
 
nothing posted on their blog in 2 years: 
https://steemit.com/@nowcoin 
 
nothing tweeted since may, 2019: 
https://twitter.com/NowcoinGame