### PR TITLE
Add Compumatrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,11 +249,11 @@ do your own research!
 ### Services
 
 * [BTSabc](http://www.btsabc.org/)
-* [Compumatrix](https://www.compumatrix.com/)
+* [Compumatrix](https://compumatrix.com/) - Business process outsourcing and home-based employment.
 * [Lykke](https://www.lykke.com/)
 * [PalmPay](https://PalmPay.io) - A chain-agnostic Point Of Sale system, using Bitshares DEx, in 104 languages.
 * [Quintric](https://quintric.com/)
-* [Moneda Par](https://monedapar.com.ar/) - a non-profit based in Argentina that allows the exchange of goods and services through mutual loans.
+* [Moneda Par](https://monedapar.com.ar/) - A non-profit based in Argentina that allows the exchange of goods and services through mutual loans.
 
 ### Games
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ do your own research!
 * [RuDEX](https://rudex.org/)
 * [WALLDEX](https://w.walldex.pro/)
 * [XBTS](https://xbts.io/)
+* [Compumatrix](https://dex.compumatrix.co/)
 
 ### Bridges
 
@@ -230,6 +231,7 @@ do your own research!
 ### Services
 
 * [BTSabc](http://www.btsabc.org/)
+* [Compumatrix](https://www.compumatrix.com/)
 * [Lykke](https://www.lykke.com/)
 * [PalmPay](https://PalmPay.io) - A chain-agnostic Point Of Sale system, using Bitshares DEx, in 104 languages.
 * [Quintric](https://quintric.com/)


### PR DESCRIPTION
I'm not sure whether Compumatrix should be added into the list.

Their main site is https://compumatrix.com/ . They have content under other domain names too, E.G. https://compumatrix.co/ and https://compumatrix.ph/ , some is not publicly accessible.

On one hand, they do run a hosted wallet for BitShares at https://dex.compumatrix.co/ . IIRC they have been with BitShares since the very beginning.

On the other hand, I don't know which category it should be in, an exchange, a service or another. Their business model is not clear to me either, some people think they're scammers.
