### PR TITLE
Remove Rudex and OmniCoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,6 @@ do your own research!
 * [EVRAZ](https://evrazdex.org/)
 * [GDEX](https://www.gdex.io/)
 * [ioBanker](https://iobanker.com/)
-* [RuDEX](https://rudex.org/)
 * [XBTS](https://xbts.io/)
 * [Compumatrix](https://dex.compumatrix.co/)
 * [AEX](https://www.aex.cool/) - An exchange with its exchange token (GAT) and stable coins (CNC) on BitShares

--- a/README.md
+++ b/README.md
@@ -272,7 +272,6 @@ foundations:
 * [Cybex](https://cybex.io/en)
 * [EOS](https://eos.io/)
 * [Hive](https://hive.io/)
-* [OmniCoin](https://omnicoin.net/)
 * [Peerplays](https://www.peerplays.com/)
 * SOUNDAC (PeerTracks) `https``://soundac.io/` - currently in maintenance, moving to other tech
 * [Scorum](https://scorumcoins.com/en-us/)


### PR DESCRIPTION
Rudex is being migrated from BitShares to another chain:

https://steemit.com/rudex/@rudex/announcement-of-rudex-migration-from-bitshares-to-graphene-dates-and-terms

OmniCoin looks like a dead project. The latest activities were in 2019.