### PR TITLE
Fixed a broken link to the graphenej java library

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Libraries capable of communicating with the BitShares blockchain.
 
 ### Java Libraries
 
-* [graphenej](https://github.com/Agorise/graphenej) - Graphene Java lib for mobile app Developers.
+* [graphenej](https://git.agorise.net/agorise/graphenej) - Graphene Java lib for mobile app Developers.
 
 ### JavaScript Libraries
 


### PR DESCRIPTION
we dumped github and host our own git now, so the link to graphenej needs to be fixed.