### PR TITLE
Remove blocktrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,6 @@ do your own research!
 
 ### Bridges
 
-* [BlockTrades](https://blocktrades.us)
 * [Exolix](https://exolix.com)
 * [GoDex](https://godex.io)
 * [SimpleSwap](https://simpleswap.io)


### PR DESCRIPTION
BlockTrades has discontinued operations.

Fixes #127.